### PR TITLE
削除機能実装1

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :update, :show]
-  before_action :move_to_index, only: [:edit, :update]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
+  before_action :move_to_index, only: [:edit, :update, ]
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -33,6 +33,11 @@ class ItemsController < ApplicationController
 
   def show
 
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to items_path, notice: '商品が削除されました。'
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:edit, :update, :show, :destroy]
-  before_action :move_to_index, only: [:edit, :update, ]
+  before_action :move_to_index, only: [:edit, :update, :destroy]
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -37,7 +37,7 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy
-    redirect_to items_path, notice: '商品が削除されました。'
+    redirect_to root_path, notice: '商品が削除されました。'
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if current_user == @item.user %>
       <%= link_to "商品の編集", edit_item_path(@item) , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class: "item-destroy" %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:new, :create, :index, :show, :edit, :update, ]
+  resources :items, only: [:new, :create, :index, :show, :edit, :update, :destroy, ]
 end


### PR DESCRIPTION
# What
ログイン状態でかつ、出品者自身が商品詳細ページから「削除」ボタンを押すことによって、自分が出品した商品情報を削除できるようになります。
# Why
商品削除機能は、出品者が自分の出品物を管理できるようにするために必要な機能です。

gyazo
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/a034b3055be9a6632ba284f652f74bb2